### PR TITLE
Fix parsing of some modern ICNS files

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var jpeg2000header = []byte{0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20}
+
 // Decode finds the largest icon listed in the icns file and returns it,
 // ignoring all other sizes. The format returned will be whatever the icon data
 // is, typically jpeg or png.
@@ -48,10 +50,14 @@ func Decode(r io.Reader) (image.Image, error) {
 		if isOsType(string(next)) {
 			iconData := data[read : read+resSize-8] // size includes header and size fields
 
-			icons = append(icons, iconReader{
-				OsType: osTypeFromID(string(next)),
-				r:      bytes.NewBuffer(iconData),
-			})
+			if bytes.Equal(iconData[:8], jpeg2000header) {
+				// skipping JPEG2000
+			} else {
+				icons = append(icons, iconReader{
+					OsType: osTypeFromID(string(next)),
+					r:      bytes.NewBuffer(iconData),
+				})
+			}
 		}
 		read += resSize-8 // size includes header and size fields
 	}

--- a/reader.go
+++ b/reader.go
@@ -33,22 +33,22 @@ func Decode(r io.Reader) (image.Image, error) {
 		read += 4
 		switch string(next) {
 		case "TOC ":
-			resSize := binary.BigEndian.Uint32(data[read : read+4])
-			read += resSize-4 // size includes header and size fields
+			tocSize := binary.BigEndian.Uint32(data[read : read+4])
+			read += tocSize-4 // size includes header and size fields
 			continue
 		case "icnV":
 			read += 4
 			continue
 		}
 
-		resSize := binary.BigEndian.Uint32(data[read : read+4])
+		dataSize := binary.BigEndian.Uint32(data[read : read+4])
 		read += 4
-		if resSize == 0 {
+		if dataSize == 0 {
 			continue // no content, we're not interested
 		}
 
-		iconData := data[read : read+resSize-8]
-		read += resSize-8 // size includes header and size fields
+		iconData := data[read : read+dataSize-8]
+		read += dataSize-8 // size includes header and size fields
 
 		if isOsType(string(next)) {
 			if bytes.Equal(iconData[:8], jpeg2000header) {

--- a/reader.go
+++ b/reader.go
@@ -47,19 +47,19 @@ func Decode(r io.Reader) (image.Image, error) {
 			continue // no content, we're not interested
 		}
 
-		if isOsType(string(next)) {
-			iconData := data[read : read+resSize-8] // size includes header and size fields
-
-			if bytes.Equal(iconData[:8], jpeg2000header) {
-				// skipping JPEG2000
-			} else {
-				icons = append(icons, iconReader{
-					OsType: osTypeFromID(string(next)),
-					r:      bytes.NewBuffer(iconData),
-				})
-			}
-		}
+		iconData := data[read : read+resSize-8]
 		read += resSize-8 // size includes header and size fields
+
+		if isOsType(string(next)) {
+			if bytes.Equal(iconData[:8], jpeg2000header) {
+				continue // skipping JPEG2000
+			}
+
+			icons = append(icons, iconReader{
+				OsType: osTypeFromID(string(next)),
+				r:      bytes.NewBuffer(iconData),
+			})
+		}
 	}
 	if len(icons) == 0 {
 		return nil, fmt.Errorf("no icons found")


### PR DESCRIPTION
This improves the parser to skip whole chunks of uninteresting data so we do not stumble over false-positive matches.
Primarily this is skipping the whole table of contents so it does not accidentally find empty images.
Additionally it skips resources that we don't recognise such as unsupported image data etc.

To test see the Apple Mail icon in Catalina