### PR TITLE
Mistakenly added unsupported image formats

### DIFF
--- a/icns.go
+++ b/icns.go
@@ -151,10 +151,8 @@ var osTypes = []OsType{
 	{ID: "ic13", Size: uint(256)},
 	{ID: "ic08", Size: uint(256)},
 	{ID: "ic07", Size: uint(128)},
-	{ID: "it32", Size: uint(128)},
 	{ID: "ic12", Size: uint(64)},
 	{ID: "ic11", Size: uint(32)},
-	{ID: "il32", Size: uint(32)},
 }
 
 // getTypeFromSize returns the type for the given icon size (in px).


### PR DESCRIPTION
Apologies for this, partially reverting #1 from 2 days ago. Adding il32 and it32 wasn't the correct fix as the image loader does not support masked RGB. It seemed to improve rendering because of issues in the parser which are now fixed.
Removing these two lines leaves the same success in parsing and rendering without attempting to load images that will fail as it's not PNG/Jpeg data it will find.

Sorry for the confusion on this. Glad the parser is handling all the files I can find now :) (unless icons are Jpeg2000 encoded of course).