### PR TITLE
Drop pkg/errors in favour of fmt error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/akavel/rsrc v0.10.2 // indirect
 	github.com/ncruces/zenity v0.7.4
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/exp v0.0.0-20210526181343-b47a03e3048a // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,6 @@ github.com/ncruces/zenity v0.7.4/go.mod h1:hLx0V51wYZLka1atR6V1N9azD3/MyYseCUhQ3
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/icns_test.go
+++ b/icns_test.go
@@ -2,6 +2,7 @@ package icns
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"image/jpeg"
 	"image/png"
@@ -9,8 +10,6 @@ import (
 	"io/ioutil"
 	"reflect"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 // TestDecode relies on Encode being correct.
@@ -351,7 +350,7 @@ func rect(x0, y0, x1, y1 int) image.Image {
 func _png(img image.Image) io.Reader {
 	buf := bytes.NewBuffer(nil)
 	if err := png.Encode(buf, img); err != nil {
-		panic(errors.Wrapf(err, "encoding png"))
+		panic(fmt.Errorf("encoding png: %w", err))
 	}
 	return buf
 }
@@ -359,7 +358,7 @@ func _png(img image.Image) io.Reader {
 func _jpg(img image.Image) io.Reader {
 	buf := bytes.NewBuffer(nil)
 	if err := jpeg.Encode(buf, img, nil); err != nil {
-		panic(errors.Wrapf(err, "encoding jpeg"))
+		panic(fmt.Errorf("encoding jpeg: %w", err))
 	}
 	return buf
 }
@@ -367,7 +366,7 @@ func _jpg(img image.Image) io.Reader {
 func _decode(r io.Reader) image.Image {
 	m, _, err := image.Decode(r)
 	if err != nil {
-		panic(errors.Wrapf(err, "decoding image"))
+		panic(fmt.Errorf("decoding image: %w", err))
 	}
 	return m
 }


### PR DESCRIPTION
This PR drops the need for `pkg/errors` by replacing it with the standard error wrapping that exists in `fmt` nowadays.
This is part of my effort to try and slim down our vendor folder in https://github.com/fyne-io/fyne by removing some of the packages that are not needed. Apart from a few lines still remaining in our cmd-tool, this was the only place the `pkg/errors` package was being used.