### PR TITLE
Remove icon type icp4,icp5,icp6

### DIFF
--- a/icns.go
+++ b/icns.go
@@ -157,10 +157,7 @@ var osTypes = []OsType{
 	{ID: "ic08", Size: uint(256)},
 	{ID: "ic07", Size: uint(128)},
 	{ID: "ic12", Size: uint(64)},
-	{ID: "icp6", Size: uint(64)},
 	{ID: "ic11", Size: uint(32)},
-	{ID: "icp5", Size: uint(32)},
-	{ID: "icp4", Size: uint(16)},
 }
 
 // getTypesFromSize returns the types for the given icon size (in px).


### PR DESCRIPTION

Some days ago, I submit a [PR](https://github.com/JackMordaunt/icns/pull/10) and add some new icon types.
But on some project such as [fyne](https://github.com/fyne-io/fyne), we found the new icons will cause some [errors](https://github.com/fyne-io/fyne/pull/2878).
And the root cause is 

> These formats are supported in standalone icns files but do not display properly if used as application icon inside a .app package.  - From [wiki](https://en.wikipedia.org/wiki/Apple_Icon_Image_format)

So I have to remove the new icon types.

That's the context.  Hope this PR will be accepted.
