### PR TITLE
ci: add winget releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,14 @@
+name: Publish to Winget
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest # Action can only run on Windows
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: JackMordaunt.icnsify
+          installers-regex: '_windows_\w+\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,12 @@ scoop bucket add extras # Ensure bucket is added first
 scoop install icnsify
 ```
 
+### [Winget](https://learn.microsoft.com/en-us/windows/package-manager/)
+
+```powershell
+winget install icnsify
+```
+
 Or from my personal bucket:
 
 ```powershell


### PR DESCRIPTION
[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @JackMordaunt. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

You can test out the action inputs in this [playground](https://bittu.eu.org/docs/wr-playground).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).

- Resolves https://github.com/JackMordaunt/icns/issues/15#issuecomment-1446143336